### PR TITLE
Fix "import jsbi" detection: match the entire name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,7 @@ export default function(babel) {
       },
       ImportDeclaration(path) {
         const source = path.node.source;
-        if (t.isStringLiteral(source) && /jsbi/i.test(source.value)) {
+        if (t.isStringLiteral(source) && /^jsbi$/i.test(source.value)) {
           for (const specifier of path.get('specifiers')) {
             if (t.isImportDefaultSpecifier(specifier)) {
               setJSBIProperty(specifier, '');


### PR DESCRIPTION
not just a substring. We don't want to drop `import {FooJsbiBar}`.

Fixes #6 .