### PR TITLE
Fix full import specifiers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,7 +154,9 @@ export default function(babel) {
       },
       ImportDeclaration(path) {
         const source = path.node.source;
-        if (t.isStringLiteral(source) && /^jsbi$/i.test(source.value)) {
+        if (t.isStringLiteral(source) &&
+            // Match exact "jsbi" or ".../jsbi.mjs" paths.
+            (/^jsbi$/i.test(source.value) || /[/\\]jsbi.mjs$/i.test(source.value))) {
           for (const specifier of path.get('specifiers')) {
             if (t.isImportDefaultSpecifier(specifier)) {
               setJSBIProperty(specifier, '');

--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,8 @@ export default function(babel) {
         const source = path.node.source;
         if (t.isStringLiteral(source) &&
             // Match exact "jsbi" or ".../jsbi.mjs" paths.
-            (/^jsbi$/i.test(source.value) || /[/\\]jsbi.mjs$/i.test(source.value))) {
+            (/^jsbi$/i.test(source.value) ||
+             /[/\\]jsbi.mjs$/i.test(source.value))) {
           for (const specifier of path.get('specifiers')) {
             if (t.isImportDefaultSpecifier(specifier)) {
               setJSBIProperty(specifier, '');

--- a/src/index.js
+++ b/src/index.js
@@ -157,7 +157,7 @@ export default function(babel) {
         if (t.isStringLiteral(source) &&
             // Match exact "jsbi" or ".../jsbi.mjs" paths.
             (/^jsbi$/i.test(source.value) ||
-             /[/\\]jsbi.mjs$/i.test(source.value))) {
+             /[/\\]jsbi\.mjs$/i.test(source.value))) {
           for (const specifier of path.get('specifiers')) {
             if (t.isImportDefaultSpecifier(specifier)) {
               setJSBIProperty(specifier, '');


### PR DESCRIPTION
Broken in #7. We must match paths, not import names.