### PR TITLE
Upgrade to last stable version of babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "test:watch": "npm run test -- --watch"
   },
   "devDependencies": {
-    "@babel/cli": "^7.5.5",
-    "@babel/core": "^7.5.5",
-    "@babel/preset-env": "^7.5.5",
-    "@babel/register": "^7.5.5",
+    "@babel/cli": "^7.14.3",
+    "@babel/core": "^7.14.3",
+    "@babel/preset-env": "^7.14.4",
+    "@babel/register": "^7.13.16",
     "eslint": "^6.2.0",
     "eslint-config-google": "^0.13.0",
     "mocha": "^6.2.0"

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export default function(babel) {
     const arg = path.node.arguments[0];
     if (t.isNumericLiteral(arg) ||
         (t.isStringLiteral(arg) && reInteger.test(arg.value))) {
-      return t.bigIntLiteral(`${ arg.value }n`);
+      return t.bigIntLiteral(`${ arg.value }`);
     }
     return t.callExpression(t.identifier('BigInt'), [arg]);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export default function(babel) {
     const arg = path.node.arguments[0];
     if (t.isNumericLiteral(arg) ||
         (t.isStringLiteral(arg) && reInteger.test(arg.value))) {
-      return t.bigIntLiteral(`${ arg.value }`);
+      return t.bigIntLiteral(arg.value);
     }
     return t.callExpression(t.identifier('BigInt'), [arg]);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -203,10 +203,10 @@ export default function(babel) {
                   '===',
                   t.unaryExpression(
                       'typeof',
-                      left
+                      left,
                   ),
-                  t.stringLiteral('bigint')
-              )
+                  t.stringLiteral('bigint'),
+              ),
           );
         }
       },

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export default function(babel) {
     const arg = path.node.arguments[0];
     if (t.isNumericLiteral(arg) ||
         (t.isStringLiteral(arg) && reInteger.test(arg.value))) {
-      return t.bigIntLiteral(arg.value);
+      return t.bigIntLiteral(`${ arg.value }`);
     }
     return t.callExpression(t.identifier('BigInt'), [arg]);
   };


### PR DESCRIPTION
Following our conversation @mathiasbynens  in https://github.com/GoogleChromeLabs/babel-plugin-transform-jsbi-to-bigint/issues/10 here's the PR.

This PR upgrades to the last version of babel and tweak the plugin code to work with it.

