### PR TITLE
Fix param count check for DataView methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ export default function(babel) {
           args);
     }
     if (dataViewMethods.has(name)) {
-      if (2 <= args.length && args.length <= 4) {
+      if (!(2 <= args.length && args.length <= 4)) {
         throw path.buildCodeFrameError(
             `${name}: incorrect number of arguments`);
       }

--- a/test/fixtures/full-import-specifier/expected.js
+++ b/test/fixtures/full-import-specifier/expected.js
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 const a = BigInt(Number.MAX_SAFE_INTEGER);
 const b = 12n;
 console.log(a + b);
@@ -49,11 +50,12 @@ Number(a);
 typeof a === "bigint";
 BigInt.asIntN(64, 42n);
 BigInt.asUintN(64, 42n);
-const buffer = new ArrayBuffer(16); // 0x7FFFFFFFFFFFFFFFn, the highest possible BigInt value that fits in
+const buffer = new ArrayBuffer(16);
+// 0x7FFFFFFFFFFFFFFFn, the highest possible BigInt value that fits in
 // a signed 64-bit integer.
-
 const max = 9223372036854775807n;
 const view = new DataView(buffer);
 view.setBigInt64(1, max);
 const result = view.getBigInt64(1);
-console.log(result.toString()); // → '9223372036854775807'
+console.log(result.toString());
+// → '9223372036854775807'

--- a/test/fixtures/short-import-specifier/expected.js
+++ b/test/fixtures/short-import-specifier/expected.js
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 const a = BigInt(Number.MAX_SAFE_INTEGER);
 const b = 12n;
 console.log(a + b);


### PR DESCRIPTION
Tests were failing locally because the condition was inverted: Having 2-4 parameters is correct, we should throw otherwise.

The dependencies pulled in by `npm install` today also format the output slightly differently.